### PR TITLE
Algunas imágenes no tienen el border radius aplicado correctamente #19

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -47,7 +47,7 @@ const HomePage: NextPage<Props> = ({users}) => {
                     height={48}
                     loading="lazy"
                     minWidth={48}
-                    objectFit="contain"
+                    objectFit="cover"
                     src={user.avatar}
                     width={48}
                   />


### PR DESCRIPTION
El objet-fit de la imagen pasa a ser 'cover' para que se puedan ver los borders